### PR TITLE
Defer actions in workflow by queueing them

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -24,5 +24,5 @@ MAILER_URL=null://localhost
 ###< symfony/swiftmailer-bundle ###
 
 ###> symfony/messenger ###
-# MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
+MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f
 ###< symfony/messenger ###

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "symfony/messenger": "*",
         "symfony/orm-pack": "^1.0",
         "symfony/security-bundle": "*",
+        "symfony/serializer-pack": "^1.0",
         "symfony/swiftmailer-bundle": "^3.2",
         "symfony/twig-bundle": "*",
         "symfony/yaml": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4e879c49bcf7cba5d1582f789fb5c3a0",
+    "content-hash": "33cb79772911cbaa42e8c2c9d1102528",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1473,6 +1473,158 @@
                 "service proxies"
             ],
             "time": "2018-09-27T13:45:01+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2017-09-11T18:02:19+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "4.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2017-11-30T07:14:17+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "psr/cache",
@@ -3481,6 +3633,82 @@
             "time": "2018-10-02T12:40:59+00:00"
         },
         {
+            "name": "symfony/property-info",
+            "version": "v4.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-info.git",
+                "reference": "a3a785d23b4fe1d1cea02be14011d654432aeb89"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/a3a785d23b4fe1d1cea02be14011d654432aeb89",
+                "reference": "a3a785d23b4fe1d1cea02be14011d654432aeb89",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/inflector": "~3.4|~4.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
+                "phpdocumentor/type-resolver": "<0.3.0",
+                "symfony/dependency-injection": "<3.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0",
+                "symfony/cache": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/serializer": "~3.4|~4.0"
+            },
+            "suggest": {
+                "phpdocumentor/reflection-docblock": "To use the PHPDoc",
+                "psr/cache-implementation": "To cache results",
+                "symfony/doctrine-bridge": "To use Doctrine metadata",
+                "symfony/serializer": "To use Serializer metadata"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Property Info Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "doctrine",
+                "phpdoc",
+                "property",
+                "symfony",
+                "type",
+                "validator"
+            ],
+            "time": "2018-08-03T11:13:38+00:00"
+        },
+        {
             "name": "symfony/routing",
             "version": "v4.1.6",
             "source": {
@@ -3713,6 +3941,117 @@
             "description": "Symfony SecurityBundle",
             "homepage": "https://symfony.com",
             "time": "2018-10-02T12:40:59+00:00"
+        },
+        {
+            "name": "symfony/serializer",
+            "version": "v4.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/serializer.git",
+                "reference": "2704442b2b85429b95659fdce1696cb8f009385f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/2704442b2b85429b95659fdce1696cb8f009385f",
+                "reference": "2704442b2b85429b95659fdce1696cb8f009385f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "phpdocumentor/type-resolver": "<0.2.1",
+                "symfony/dependency-injection": "<3.4",
+                "symfony/property-access": "<3.4",
+                "symfony/property-info": "<3.4",
+                "symfony/yaml": "<3.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "doctrine/cache": "~1.0",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0",
+                "symfony/cache": "~3.4|~4.0",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/http-foundation": "~3.4|~4.0",
+                "symfony/property-access": "~3.4|~4.0",
+                "symfony/property-info": "~3.4|~4.0",
+                "symfony/validator": "~3.4|~4.0",
+                "symfony/yaml": "~3.4|~4.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
+                "doctrine/cache": "For using the default cached annotation reader and metadata cache.",
+                "psr/cache-implementation": "For using the metadata cache.",
+                "symfony/config": "For using the XML mapping loader.",
+                "symfony/http-foundation": "To use the DataUriNormalizer.",
+                "symfony/property-access": "For using the ObjectNormalizer.",
+                "symfony/property-info": "To deserialize relations.",
+                "symfony/yaml": "For using the default YAML mapping loader."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Serializer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Serializer Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-10-02T12:40:59+00:00"
+        },
+        {
+            "name": "symfony/serializer-pack",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/serializer-pack.git",
+                "reference": "35cea385ea44d1f40ec12571996bf768fbe409de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/serializer-pack/zipball/35cea385ea44d1f40ec12571996bf768fbe409de",
+                "reference": "35cea385ea44d1f40ec12571996bf768fbe409de",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.0",
+                "php": "^7.0",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0",
+                "symfony/cache": "^3.3|^4.0",
+                "symfony/property-access": "^3.3|^4.0",
+                "symfony/property-info": "^3.3|^4.0",
+                "symfony/serializer": "^3.3|^4.0"
+            },
+            "type": "symfony-pack",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A pack for the Symfony serializer",
+            "time": "2017-12-12T01:48:53+00:00"
         },
         {
             "name": "symfony/swiftmailer-bundle",
@@ -4065,6 +4404,56 @@
                 "templating"
             ],
             "time": "2018-07-13T07:18:09+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2018-01-29T19:49:41+00:00"
         },
         {
             "name": "zendframework/zend-code",

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -1,12 +1,12 @@
 framework:
     messenger:
         transports:
-            # Uncomment the following line to enable a transport named "amqp"
-            # amqp: '%env(MESSENGER_TRANSPORT_DSN)%'
+            amqp_invite_creation: '%env(MESSENGER_TRANSPORT_DSN)%/invites'
+            amqp_events: '%env(MESSENGER_TRANSPORT_DSN)%/events'
 
         routing:
-            # Route your messages to the transports
-            # 'App\Message\YourMessage': amqp
+            App\Message\CreateInvitations: amqp_invite_creation
+            App\Message\InvitationRedeemed: amqp_events
 
         buses:
             default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,16 @@ services:
             MYSQL_USER: dbuser
             MYSQL_PASSWORD: dbpass
 
+    queue:
+        image: rabbitmq:management
+        ports:
+            - 15672:15672
+
     app:
         build: ./docker/app
         links:
             - db
+            - queue
         volumes:
             - .:/opt/invite-registration:cached
         ports:
@@ -26,6 +32,7 @@ services:
             APP_DEBUG: 1
             APP_SECRET: "90bdd6ea7f7117657cbc1e304392971f"
             DATABASE_URL: "mysql://dbuser:dbpass@db:3306/invite_registration"
+            MESSENGER_TRANSPORT_DSN: "amqp://guest:guest@queue:5672/%2f"
             MAILER_URL: "null://localhost"
 
 volumes:

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -71,4 +71,9 @@ class User implements UserInterface
     public function eraseCredentials(): void
     {
     }
+
+    public function __toString(): string
+    {
+        return $this->getEmail();
+    }
 }

--- a/src/Message/CreateInvitations.php
+++ b/src/Message/CreateInvitations.php
@@ -2,18 +2,16 @@
 
 namespace App\Message;
 
-use App\Entity\User;
-
 class CreateInvitations
 {
     private $owner;
 
-    public function __construct(User $owner)
+    public function __construct(string $owner)
     {
         $this->owner = $owner;
     }
 
-    public function getOwner(): User
+    public function getOwner(): string
     {
         return $this->owner;
     }

--- a/src/Message/InvitationRedeemed.php
+++ b/src/Message/InvitationRedeemed.php
@@ -2,18 +2,16 @@
 
 namespace App\Message;
 
-use App\Entity\Invitation;
-
 class InvitationRedeemed
 {
     private $invitation;
 
-    public function __construct(Invitation $invitation)
+    public function __construct(string $invitation)
     {
         $this->invitation = $invitation;
     }
 
-    public function getInvitation(): Invitation
+    public function getInvitation(): string
     {
         return $this->invitation;
     }

--- a/src/Message/RedeemInvitation.php
+++ b/src/Message/RedeemInvitation.php
@@ -2,14 +2,12 @@
 
 namespace App\Message;
 
-use App\Entity\User;
-
 class RedeemInvitation
 {
     private $inviteCode;
     private $invitedUser;
 
-    public function __construct(string $inviteCode, User $invitedUser)
+    public function __construct(string $inviteCode, string $invitedUser)
     {
         $this->inviteCode = $inviteCode;
         $this->invitedUser = $invitedUser;
@@ -20,7 +18,7 @@ class RedeemInvitation
         return $this->inviteCode;
     }
 
-    public function getInvitedUser(): User
+    public function getInvitedUser(): string
     {
         return $this->invitedUser;
     }

--- a/src/MessageHandler/CreateInvitationsHandler.php
+++ b/src/MessageHandler/CreateInvitationsHandler.php
@@ -4,22 +4,24 @@ namespace App\MessageHandler;
 
 use App\Message\CreateInvitations;
 use App\Registration\InvitationGenerator;
+use App\Registration\UserProvider;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
 class CreateInvitationsHandler implements MessageHandlerInterface
 {
+    private $userProvider;
     private $invitationGenerator;
 
-    public function __construct(InvitationGenerator $invitationGenerator)
+    public function __construct(UserProvider $userProvider, InvitationGenerator $invitationGenerator)
     {
+        $this->userProvider = $userProvider;
         $this->invitationGenerator = $invitationGenerator;
     }
 
     public function __invoke(CreateInvitations $createInvitationsMessage): void
     {
-        $this->invitationGenerator->generateMultiple(
-            $createInvitationsMessage->getOwner(),
-            $createInvitationsMessage->getCount()
-        );
+        $owner = $this->userProvider->getUserByEmail($createInvitationsMessage->getOwner());
+
+        $this->invitationGenerator->generateMultiple($owner, $createInvitationsMessage->getCount());
     }
 }

--- a/src/MessageHandler/NotifyInviteOwnerHandler.php
+++ b/src/MessageHandler/NotifyInviteOwnerHandler.php
@@ -4,19 +4,24 @@ namespace App\MessageHandler;
 
 use App\Message\InvitationRedeemed;
 use App\Registration\InvitationNotifier;
+use App\Registration\InvitationProvider;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
 class NotifyInviteOwnerHandler implements MessageHandlerInterface
 {
+    private $invitationProvider;
     private $notifier;
 
-    public function __construct(InvitationNotifier $notifier)
+    public function __construct(InvitationProvider $invitationProvider, InvitationNotifier $notifier)
     {
+        $this->invitationProvider = $invitationProvider;
         $this->notifier = $notifier;
     }
 
     public function __invoke(InvitationRedeemed $invitationRedeemedMessage): void
     {
-        $this->notifier->notifyInvitingUser($invitationRedeemedMessage->getInvitation()->getOwner());
+        $invitation = $this->invitationProvider->getRedeemedInvitation($invitationRedeemedMessage->getInvitation());
+
+        $this->notifier->notifyInvitingUser($invitation->getOwner());
     }
 }

--- a/src/MessageHandler/RedeemInvitationHandler.php
+++ b/src/MessageHandler/RedeemInvitationHandler.php
@@ -7,21 +7,25 @@ use App\Message\InvitationRedeemed;
 use App\Message\RedeemInvitation;
 use App\Registration\InvitationProvider;
 use App\Registration\InvitationRedeemer;
+use App\Registration\UserProvider;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 class RedeemInvitationHandler implements MessageHandlerInterface
 {
     private $invitationProvider;
+    private $userProvider;
     private $invitationRedeemer;
     private $messageBus;
 
     public function __construct(
         InvitationProvider $invitationProvider,
+        UserProvider $userProvider,
         InvitationRedeemer $invitationRedeemer,
         MessageBusInterface $messageBus
     ) {
         $this->invitationProvider = $invitationProvider;
+        $this->userProvider = $userProvider;
         $this->invitationRedeemer = $invitationRedeemer;
         $this->messageBus = $messageBus;
     }
@@ -29,10 +33,12 @@ class RedeemInvitationHandler implements MessageHandlerInterface
     public function __invoke(RedeemInvitation $redeemInvitationMessage): void
     {
         $invitation = $this->invitationProvider->getOpenInvitation($redeemInvitationMessage->getInviteCode());
-        $this->invitationRedeemer->redeem($invitation, $redeemInvitationMessage->getInvitedUser());
+        $inviteduser = $this->userProvider->getUserByEmail($redeemInvitationMessage->getInvitedUser());
 
-        $this->messageBus->dispatch(new CreateInvitations($redeemInvitationMessage->getInvitedUser()));
+        $this->invitationRedeemer->redeem($invitation, $inviteduser);
 
-        $this->messageBus->dispatch(new InvitationRedeemed($invitation));
+        $this->messageBus->dispatch(new CreateInvitations((string) $inviteduser));
+
+        $this->messageBus->dispatch(new InvitationRedeemed((string) $invitation));
     }
 }

--- a/src/MessageHandler/RegisterUserHandler.php
+++ b/src/MessageHandler/RegisterUserHandler.php
@@ -23,6 +23,6 @@ class RegisterUserHandler implements MessageHandlerInterface
     {
         $createdUser = $this->userCreator->create($registerUserMessage->email, $registerUserMessage->plainPassword);
 
-        $this->messageBus->dispatch(new RedeemInvitation($registerUserMessage->inviteCode, $createdUser));
+        $this->messageBus->dispatch(new RedeemInvitation($registerUserMessage->inviteCode, (string) $createdUser));
     }
 }

--- a/src/Registration/Exceptions/InvalidEmailException.php
+++ b/src/Registration/Exceptions/InvalidEmailException.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+
+namespace App\Registration\Exceptions;
+
+use DomainException;
+
+final class InvalidEmailException extends DomainException
+{
+}

--- a/src/Registration/InvitationProvider.php
+++ b/src/Registration/InvitationProvider.php
@@ -40,4 +40,20 @@ final class InvitationProvider
             );
         }
     }
+
+    /**
+     * @throws InvalidInvitationException When invite code is not redeemable.
+     */
+    public function getRedeemedInvitation(string $code): Invitation
+    {
+        try {
+            return $this->invitationRepository->findRedeemedInvitationByCode($code);
+        } catch (NoResultException $exception) {
+            throw new InvalidInvitationException(
+                sprintf('Could not find an open invitation matching the code "%s"', $code),
+                0,
+                $exception
+            );
+        }
+    }
 }

--- a/src/Registration/UserProvider.php
+++ b/src/Registration/UserProvider.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace App\Registration;
+
+use App\Entity\User;
+use App\Registration\Exceptions\InvalidEmailException;
+use App\Repository\UserRepository;
+use Doctrine\ORM\NoResultException;
+
+final class UserProvider
+{
+    private $userRepository;
+
+    public function __construct(UserRepository $userRepository)
+    {
+        $this->userRepository = $userRepository;
+    }
+
+    public function getUserByEmail(string $email): User
+    {
+        try {
+            return $this->userRepository->findUserByEmail($email);
+        } catch (NoResultException $exception) {
+            throw new InvalidEmailException(
+                sprintf('Could not find a registered user for email "%s"', $email),
+                0,
+                $exception
+            );
+        }
+    }
+}

--- a/src/Repository/InvitationRepository.php
+++ b/src/Repository/InvitationRepository.php
@@ -35,4 +35,18 @@ class InvitationRepository extends ServiceEntityRepository
             ->getQuery()
             ->getSingleResult();
     }
+
+    /**
+     * @throws NoResultException When no invite code matches the criteria
+     */
+    public function findRedeemedInvitationByCode(string $id): Invitation
+    {
+        $builder = $this->createQueryBuilder('invitation');
+
+        return $builder
+            ->where('invitation.id = :id AND invitation.redeemedAt IS NOT NULL')
+            ->setParameter('id', $id)
+            ->getQuery()
+            ->getSingleResult();
+    }
 }

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace App\Repository;
+
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\NoResultException;
+
+class UserRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, User::class);
+    }
+
+    public function findUserByEmail(string $email): User
+    {
+        $user = $this->findOneBy(['email' => $email]);
+
+        if (null === $user) {
+            throw new NoResultException();
+        }
+
+        return $user;
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -101,6 +101,15 @@
     "ocramius/proxy-manager": {
         "version": "2.1.1"
     },
+    "phpdocumentor/reflection-common": {
+        "version": "1.0.1"
+    },
+    "phpdocumentor/reflection-docblock": {
+        "version": "4.3.0"
+    },
+    "phpdocumentor/type-resolver": {
+        "version": "0.4.0"
+    },
     "psr/cache": {
         "version": "1.0.1"
     },
@@ -260,6 +269,9 @@
     "symfony/property-access": {
         "version": "v4.1.6"
     },
+    "symfony/property-info": {
+        "version": "v4.1.6"
+    },
     "symfony/routing": {
         "version": "4.0",
         "recipe": {
@@ -280,6 +292,12 @@
             "version": "3.3",
             "ref": "f8a63faa0d9521526499c0a8f403c9964ecb0527"
         }
+    },
+    "symfony/serializer": {
+        "version": "v4.1.6"
+    },
+    "symfony/serializer-pack": {
+        "version": "v1.0.1"
     },
     "symfony/stopwatch": {
         "version": "v4.1.6"
@@ -322,6 +340,9 @@
     },
     "twig/twig": {
         "version": "v2.5.0"
+    },
+    "webmozart/assert": {
+        "version": "1.3.0"
     },
     "zendframework/zend-code": {
         "version": "3.3.1"


### PR DESCRIPTION
Queues the generation of invite codes and sending notification emails.

In order to process these message you need to run the command `messenger:consume-messages`, e.g. like this:

```
bin/console messenger:consume-messages amqp_invite_creation --limit=1 -vvv
bin/console messenger:consume-messages amqp_events --limit=1 -vvv
```

This will consume one message and then exit. The messages being processed is logged to the CLI, making it easier to backtrace what is happening.